### PR TITLE
Issue 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Defaults to false.
 
 Bas64 encoded SVGs will be 33% larger than the size on disk. You should therefore only use this for small images where the convenience of having them available on startup (e.g. rendering immediately to a canvas without co-ordinating asynchronous loading of several images) outweighs the cost.
 
+### removeWhitespace
+
+Defaults to false.
+
+Remove all whitespace from SVG markup
+
 ## Sources
 
 This plugin was built (based on the rollup-plugin-image plugin) because it appears that the two existing suitable plugins:

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,10 @@ export default function svg (options = {}) {
         return null
       }
 
-      const content = code.trim()
+      let content = code.trim()
+      if (options.removeWhitespace) {
+        content = content.replace(/\s/g, '')
+      }
       const encoded = options.base64 ? toDataUrl(content) : JSON.stringify(content)
 
       return { code: `export default ${encoded}`, map: { mappings: '' } }


### PR DESCRIPTION
Fix https://github.com/antony/rollup-plugin-svg/issues/2.
Add option "removeWhitespace" that removes whitespace from SVG markup